### PR TITLE
Fix directory creation on Unix

### DIFF
--- a/RPGMakerDecrypter.Decrypter/RGSSAD.cs
+++ b/RPGMakerDecrypter.Decrypter/RGSSAD.cs
@@ -92,7 +92,12 @@ namespace RPGMakerDecrypter.Decrypter
             if (createDirectory)
             {
                 // Create output directory if it does not exist
-                string directoryPath = Path.GetDirectoryName(archivedFile.Name);
+                string filePathStr = archivedFile.Name;
+                if (Path.DirectorySeparatorChar != '\\') {
+                    // On Unix-like systems we need to correct that the path names encoded in RGSSAD always use Windows path delimiters.
+                    filePathStr = filePathStr.Replace('\\', Path.DirectorySeparatorChar);
+                }
+                string directoryPath = Path.GetDirectoryName(filePathStr);
 
                 if (directoryPath == null)
                 {
@@ -104,7 +109,7 @@ namespace RPGMakerDecrypter.Decrypter
                     Directory.CreateDirectory(Path.Combine(outputDirectoryPath, directoryPath));
                 }
 
-                outputPath = Path.Combine(outputDirectoryPath, archivedFile.Name);
+                outputPath = Path.Combine(outputDirectoryPath, filePathStr);
             }
             else
             {


### PR DESCRIPTION
Great job porting to dotnet 6 and adding a Linux version! This tiny PR just fixes a bug on Linux where due to the fact that RGSSAD hardcodes the path delimiter to `\` and because dotnet on Unix-like hardcodes the path delimiter to `/`, it wasn't treating the paths from `archivedFile.Name` as paths, thus creating files like this:

![image](https://user-images.githubusercontent.com/819705/224931611-8840852f-8c22-4ba4-a8a9-c7d6eb9459e5.png)

... instead of directories. This PR fixes that by checking for what the path delimiter is and then simply replacing the archive's filenames with that.